### PR TITLE
fix Webpack "DeprecationWarning: Tapable.plugin is deprecated."

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -20,7 +20,7 @@ class DeclarationBundlerPlugin
 	apply(compiler)
 	{
 		//when the compiler is ready to emit files
-		compiler.plugin('emit', (compilation,callback) =>
+		compiler.hooks.emit.tapAsync('DeclarationBundlerPlugin', (compilation,callback) =>
 		{
 			//collect all generated declaration files
 			//and remove them from the assets that will be emited


### PR DESCRIPTION
Full message: "DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead". I replaced it with "compiler.hooks.emit.tapAsync(...)" instead of "compiler.plugin(...)".